### PR TITLE
Fix documentation to say little-endian instead of big-endian

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ As in py-aiger, when writing combinatorial circuits, the Sequential
 Circuit DSL can be somewhat clumsy. For this common usecase, we have
 developed the BitVector Expression DSL. This DSL actually consists of
 two DSLs for signed and unsigned BitVectors.  All circuits generated
-this way have a single output word. We use a **big-endian** encoding
-where the most significant digit is the first element of the tuple
+this way have a single output word. We use a **little-endian** encoding
+where the least significant digit is the first element of the tuple
 representing the word. For signed numbers, two's complement is used.
 
 ```python


### PR DESCRIPTION
It's easy to check little-endian is used with `simulate()`:

```
In [66]: from aiger_bv import uatom

In [67]: uatom(6, 1)[0].aigbv.simulate([ {} ])
Out[67]: [({'24a21922-c6a5-11ef-965d-5ce0c5b354bb': (True,)}, {})]
```

Only in little-endian is the *first* bit of `1` in bitvector of width 6 true.